### PR TITLE
Annotate only top level calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@
 [![Dependencies](https://img.shields.io/david/morlay/babel-plugin-annotate-pure-call-in-variable-declarator.svg?style=flat-square)](https://david-dm.org/morlay/babel-plugin-annotate-pure-call-in-variable-declarator)
 [![License](https://img.shields.io/npm/l/babel-plugin-annotate-pure-call-in-variable-declarator.svg?style=flat-square)](https://npmjs.org/package/babel-plugin-annotate-pure-call-in-variable-declarator)
 
-Automated annotate **#__PURE__** to call expression which in **variable declarator**, 
-**assignment expression** and **arguments of call expression**
+Automated annotating with **#__PURE__** comment to call expressions in assignment contexts.
 
 ### Purpose
 
-help to annotate **#__PURE__** to drop dead code in [Webpack](https://github.com/webpack/webpack) 
-for uglyfiy and tree shaking
+Help to annotate with **#__PURE__** in order to drop dead code when using [UglifyJS](https://github.com/mishoo/UglifyJS2).
 
 
 Will transform

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-annotate-pure-call-in-variable-declarator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -475,7 +475,7 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
@@ -488,14 +488,14 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.0",
+            "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
           }
         },
         "core-js": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-          "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
           "dev": true
         },
         "regenerator-runtime": {
@@ -1160,13 +1160,13 @@
       }
     },
     "fs-extra": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
-      "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
+        "jsonfile": "4.0.0",
         "universalify": "0.1.1"
       }
     },
@@ -2011,9 +2011,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
@@ -3072,7 +3072,7 @@
         "babel-plugin-istanbul": "4.1.4",
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-preset-jest": "20.0.3",
-        "fs-extra": "4.0.1",
+        "fs-extra": "4.0.2",
         "jest-config": "20.0.4",
         "jest-util": "20.0.3",
         "pkg-dir": "2.0.0",
@@ -3340,13 +3340,13 @@
         "resolve": "1.4.0",
         "semver": "5.4.1",
         "tslib": "1.7.1",
-        "tsutils": "2.8.1"
+        "tsutils": "2.8.2"
       }
     },
     "tsutils": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.1.tgz",
-      "integrity": "sha1-N3FATnyp8L7fXZGaR6SxiQpo7/8=",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.2.tgz",
+      "integrity": "sha1-LBSGukMSYIRbCsb5Aq/Z1wio6mo=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"


### PR DESCRIPTION
Thanks for the plugin! I was actually thinking about writing this myself and here it is, so great work 👏 

I dont see any reason (I might be wrong) to annotate inner calls - they wont be tree shaken anyway.

Before this change such code:
```js
export const A = (() => {
  var B = call();
})();
```
would result in
```js
export const A = /*#__PURE__*/(() => {
  var B = /*#__PURE__*/call();
})();
```
not it is 
```js
export const A = /*#__PURE__*/(() => {
  var B = call();
})();
```

Aint sure if my check for the 'top level' call is the best, but I couldnt figure out better for now.